### PR TITLE
INFRA-407: Conditionally skip set settings.xml step for `maven-build-test` workflow.

### DIFF
--- a/.github/workflows/maven-build-test.yml
+++ b/.github/workflows/maven-build-test.yml
@@ -18,6 +18,12 @@ on:
         required: false
         type: string
         default: ''
+      use-secrets:
+        description: 'Whether to use secrets or not'
+        required: false
+        type: boolean
+        default: false
+
     secrets:
       NEXUS_USERNAME:
         required: true
@@ -38,6 +44,7 @@ jobs:
           cache: 'maven'
 
       - name: Set settings.xml
+        if: ${{ inputs.use-secrets }}
         uses: s4u/maven-settings-action@v3.0.0
         with:
           servers: |
@@ -57,7 +64,12 @@ jobs:
               "password": "${{ secrets.NEXUS_PASSWORD }}"
             },
             {
-              "id": "mks-nexus-public-releases",
+              "id": "mks-nexus-private-snapshots",
+              "username": "${{ secrets.NEXUS_USERNAME }}",
+              "password": "${{ secrets.NEXUS_PASSWORD }}"
+            },
+            {
+              "id": "mks-nexus-private-releases",
               "username": "${{ secrets.NEXUS_USERNAME }}",
               "password": "${{ secrets.NEXUS_PASSWORD }}"
             }]


### PR DESCRIPTION

This will affect the private repos. We have explicitly specified to use of secrets for workflows using the `maven-build-test` reusable workflow. i.e.
```yaml
  validate:
    uses: mekomsolutions/shared-github-workflow/.github/workflows/maven-build-test.yml@main
    with:
      java-version: "8"
      use-secrets: true
    secrets:
      NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
      NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
```