### PR TITLE
OZ-467: Share build artifacts btw maven and docker jobs if needed.

### DIFF
--- a/.github/workflows/maven-check-deps-build-publish.yml
+++ b/.github/workflows/maven-check-deps-build-publish.yml
@@ -18,6 +18,21 @@ on:
         description: 'Java distribution to use for building'
         required: false
         type: string
+      upload-artifacts:
+        description: 'Whether to upload build artifacts or not'
+        required: false
+        type: boolean
+        default: false
+      artifact-path:
+        description: 'Path to the artifact(s) to upload'
+        required: false
+        type: string
+        default: ''
+      artifact-name:
+        description: 'Name of the artifact(s) to upload'
+        required: false
+        type: string
+        default: 'artifact'
     secrets:
       NEXUS_USERNAME:
         required: true
@@ -191,6 +206,9 @@ jobs:
       java-version: ${{ inputs.java-version }}
       java-distribution: ${{ inputs.java-distribution }}
       maven-args: ${{ inputs.maven-args }}
+      upload-artifacts: ${{ inputs.upload-artifacts }}
+      artifact-path: ${{ inputs.artifact-path }}
+      artifact-name: ${{ inputs.artifact-name }}
     secrets:
       NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
       NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Publish maven artifacts
         run: 'mvn --batch-mode clean deploy ${{ inputs.maven-args }}'
 
-      - name: Upload artifacts
+      - name: Upload artifacts to GitHub
         if: ${{ inputs.upload-artifacts }}
         uses: actions/upload-artifact@v4
         with:

--- a/docs/maven-check-deps-build-publish.md
+++ b/docs/maven-check-deps-build-publish.md
@@ -1,6 +1,6 @@
 # Check for Dependency Changes Workflow
 
-This workflow is named `Check for dependency changes`. It is designed to check for changes in the dependencies of a Maven project and build the project if changes are detected. It also publishes the build using a shared GitHub workflow.
+This workflow is named `Check for dependency changes`. It is designed to check for changes in the dependencies of a Maven project and build the project if changes are detected. It also publishes the build to Nexus using a shared GitHub workflow. Optionally, it can upload the artifacts to GitHub using the `upload-artifacts` action.
 
 ## Workflow Triggers
 
@@ -11,6 +11,9 @@ This workflow is triggered when it is called from another workflow.
 - `maven-args`: Additional arguments to pass to Maven. Default is `-DskipTests=true`.
 - `java-version`: Java version to use for building. Default is `17`.
 - `java-distribution`: Java distribution to use for building. Default is `temurin`.
+- `upload-artifacts`: Whether to upload the artifacts to GitHub using upload-artifacts action. Default is `false`.
+- `upload-artifacts-path`: The path to the artifacts to upload. Default is empty.
+- `upload-artifacts-name`: The name of the artifacts to upload. Default is `artifact`.
 
 ## Secrets
 


### PR DESCRIPTION
Allow `maven-check-deps-build-publish.yml` to upload build artifacts conditionally. This will enable the sharing of artifacts between jobs.