### PR TITLE
Add support for Maven arguments in Spotless Check workflow.

### DIFF
--- a/.github/workflows/maven-spotless-check.yml
+++ b/.github/workflows/maven-spotless-check.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: 'temurin'
+      maven-args:
+        description: 'Maven arguments'
+        required: false
+        type: string
+        default: ''
 
 
 concurrency:
@@ -36,4 +41,4 @@ jobs:
           cache: 'maven'
       
       - name: Run Spotless Check
-        run:  mvn spotless:check
+        run:  mvn spotless:check ${{ inputs.maven-args }}

--- a/docs/maven-spotless-check.md
+++ b/docs/maven-spotless-check.md
@@ -10,6 +10,7 @@ This workflow is triggered when it is called from another workflow.
 
 - `java-version`: Java version to use for building. Default is `17`.
 - `java-distribution`: Java distribution to use for building. Default is `temurin`.
+- `maven-args`: Additional arguments to pass to the Maven command. Default to empty.
 
 ## Jobs
 


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/jira/software/c/projects/OZ/issues/OZ-438

Adds support for additional Maven arguments in Spotless Check workflow.