### PR TITLE
OZ-547: Set a timeout to check for dependency changes GA Job.

### DIFF
--- a/.github/workflows/maven-check-deps-build-publish.yml
+++ b/.github/workflows/maven-check-deps-build-publish.yml
@@ -43,6 +43,11 @@ on:
         required: false
         type: string
         default: 'https://openmrs-cd.mekomsolutions.net/generic-webhook-trigger/invoke'
+      check-deps-timeout-minutes:
+        description: 'Timeout for checking dependencies in minutes. Default is 10 minutes.'
+        required: false
+        type: number
+        default: 10
     secrets:
       NEXUS_USERNAME:
         required: true
@@ -56,6 +61,7 @@ on:
 
 jobs:
   check-for-dependency-changes:
+    timeout-minutes: ${{ inputs.check-deps-timeout-minutes }}
     outputs:
       hasChanged: ${{ steps.compareDependencyChanges.outputs.hasChanged }}
     runs-on: ubuntu-latest

--- a/docs/maven-check-deps-build-publish.md
+++ b/docs/maven-check-deps-build-publish.md
@@ -16,6 +16,7 @@ This workflow is triggered when it is called from another workflow.
 - `upload-artifacts-name`: The name of the artifacts to upload. Default is `artifact`.
 - `notify-ocd3`: Whether to notify the OCD3 about the new published artifacts. Default is `false`.
 - `ocd3-webhook-url`: The Webhook URL of the OCD3 to notify. Default is `https://openmrs-cd.mekomsolutions.net/generic-webhook-trigger/invoke`.
+- `check-deps-timeout-minutes`: The timeout in minutes for the check-for-dependency-changes job. Default is `10`.
 
 ## Secrets
 


### PR DESCRIPTION
This PR introduces a configurable timeout for the `check-for-dependency-changes` job in our Shared GitHub Actions workflow. The timeout can be set through the input variable `check-deps-timeout-minutes`. If not explicitly set, it defaults to 10 minutes.

This change ensures that the `check-for-dependency-changes` job does not run indefinitely and potentially consumes unnecessary GitHub Actions minutes. It provides more control over the job's execution time and allows for adjustments based on the specific needs of the project.