### PR TITLE
OZ-340: Add Maven License Check shared GA workflow.

### DIFF
--- a/.github/workflows/maven-license-check.yml
+++ b/.github/workflows/maven-license-check.yml
@@ -1,0 +1,44 @@
+name: Run License Check
+
+on:
+  workflow_call:
+    inputs:
+      java-version:
+        description: 'Java version to use for building'
+        required: false
+        type: string
+        default: '17'
+      java-distribution:
+        description: 'Java distribution to use for building'
+        required: false
+        type: string
+        default: 'temurin'
+      maven-args:
+        description: 'Maven arguments'
+        required: false
+        type: string
+        default: ''
+
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up JDK ${{ inputs.java-version }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ inputs.java-version }}
+          distribution: ${{ inputs.java-distribution }}
+          cache: 'maven'
+
+      - name: Run License Check
+        run:  mvn license:check ${{ inputs.maven-args }}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The following reusable workflows are available in this repository:
 - [Maven Spotless Check](docs/maven-spotless-check.md)
 - [Notify OCD3](docs/ocd3-notify.md)
 - [Maven Check Dependency Changes ](docs/maven-check-deps-build-publish.md)
+- [Maven License Check](docs/maven-license-check.md)
 
 ## Usage
 

--- a/docs/maven-license-check.md
+++ b/docs/maven-license-check.md
@@ -1,0 +1,39 @@
+# Maven License Check Workflow
+
+This workflow is named `Maven License Check`. It is designed to check the code licensing of a Maven project using the License Maven Plugin.
+
+## Workflow Triggers
+
+This workflow is triggered when it is called from another workflow.
+
+## Inputs
+
+- `java-version`: Java version to use for building. Default is `17`.
+- `java-distribution`: Java distribution to use for building. Default is `temurin`.
+- `maven-args`: Additional arguments to pass to the Maven command. Default to empty.
+
+## Jobs
+
+1. `check`: Checks the code licensing using the License Maven Plugin.
+
+## Usage
+
+This workflow is designed to be used as part of the CI/CD pipeline. It is triggered automatically on every push and pull request.
+
+```yaml
+name: Maven License Check
+
+on:
+  push: [main]
+  pull_request: [main]
+
+jobs:
+    check:
+      uses: mekomsolutions/shared-github-workflow/.github/workflows/maven-license-check.yml@main
+      with:
+        java-version: 17 # Optional, default is 17
+        java-distribution: temurin # Optional, default is temurin
+        maven-args: '' # Optional, default is empty
+```
+
+For more information about reusable workflows, see the official GitHub documentation: [https://docs.github.com/en/actions/using-workflows/reusing-workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows).


### PR DESCRIPTION
This PR introduces a new shared GitHub Actions workflow for performing a Maven License Check. This workflow is designed to check the code licensing of a Maven project using the License Maven Plugin.