### PR TITLE
Add check for existence of `pom.xml` before getting version in `docker-build-publish` workflow

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -62,11 +62,14 @@ jobs:
         if: inputs.image-version == ''
         id: get_version
         run: |
-          # Workaround to fail if pom.xml does not exist.
-          mvn install -DskipTests
-          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo $VERSION
-          echo ::set-output name=version::$VERSION
+          if [ -f pom.xml ]; then
+            VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+            echo $VERSION
+            echo ::set-output name=version::$VERSION
+          else
+            echo "pom.xml does not exist."
+            exit 1
+          fi
 
       - name: Prepare
         id: prep


### PR DESCRIPTION
This PR adds a check if the `pom.xml` file exists. If it does, the `mvn` command is executed to get the project version. If the `pom.xml` file does not exist, prints "pom.xml doesn't exists" and exits with a status code of 1, indicating an error.