### PR TITLE
OZ-631: Added optional inputs to accept Docker Hub secrets.

### DIFF
--- a/.github/workflows/maven-build-test.yml
+++ b/.github/workflows/maven-build-test.yml
@@ -34,6 +34,10 @@ on:
         required: true
       NEXUS_PASSWORD:
         required: true
+      DOCKER_HUB_USERNAME:
+        required: false
+      DOCKER_HUB_PASSWORD:
+        required: false
 
 jobs:
   build:


### PR DESCRIPTION
[OZ-631](https://mekomsolutions.atlassian.net/browse/OZ-631) - The change allows providing secrets to log into Mekom dockerhub, this is required for tests that use testcontainers with images from the Mekom repo