### PR TITLE
OZ-631: Added optional step to log into private docker hub

### DIFF
--- a/.github/workflows/maven-build-test.yml
+++ b/.github/workflows/maven-build-test.yml
@@ -28,6 +28,11 @@ on:
         required: false
         type: string
         default: 'verify'
+      login-docker:
+        description: 'Whether to log into the private docker hub'
+        required: false
+        type: boolean
+        default: false
 
     secrets:
       NEXUS_USERNAME:
@@ -87,6 +92,13 @@ jobs:
               "username": "${{ secrets.NEXUS_USERNAME }}",
               "password": "${{ secrets.NEXUS_PASSWORD }}"
             }]
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        if: ${{ inputs.login-docker }}
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
       
       - name: Build with Maven
         run: 'mvn --batch-mode --no-transfer-progress --update-snapshots clean ${{ inputs.maven-phase }} ${{ inputs.maven-args }}'


### PR DESCRIPTION
[OZ-631](https://mekomsolutions.atlassian.net/browse/OZ-631) - The change add a step to log into the private docker hub, which is required for tests that use testcontainers with images from the Mekom docker hub

[OZ-631]: https://mekomsolutions.atlassian.net/browse/OZ-631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ