### PR TITLE
OZ-668: Add support for setting Docker credentials for fabric8 Docker plugin in `settings.xml`

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -38,6 +38,11 @@ on:
         required: true
       NEXUS_PASSWORD:
         required: true
+      DOCKER_HUB_USERNAME:
+        required: false
+      DOCKER_HUB_PASSWORD:
+        required: false
+
 
 
 jobs:
@@ -86,6 +91,11 @@ jobs:
               "id": "mks-nexus-private-releases",
               "username": "${{ secrets.NEXUS_USERNAME }}",
               "password": "${{ secrets.NEXUS_PASSWORD }}"
+            },
+            {
+              "id": "docker.io",
+              "username": "${{ secrets.DOCKER_HUB_USERNAME || 'user'}}",
+              "password": "${{ secrets.DOCKER_HUB_PASSWORD || 'password'}}"
             }]
 
       - name: Publish maven artifacts

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -94,8 +94,8 @@ jobs:
             },
             {
               "id": "docker.io",
-              "username": "${{ secrets.DOCKER_HUB_USERNAME || 'user'}}",
-              "password": "${{ secrets.DOCKER_HUB_PASSWORD || 'password'}}"
+              "username": "${{ secrets.DOCKER_HUB_USERNAME || ''}}",
+              "password": "${{ secrets.DOCKER_HUB_PASSWORD || ''}}"
             }]
 
       - name: Publish maven artifacts


### PR DESCRIPTION
We need to be able to build images with embedded configs. We are currently trying to do this using the fabric8 Docker plugin. We need to add a server in the settings.xml to allow pushing the images.