### PR TITLE
INFRA-480: Remove unary operator and read ref from github.ref only

### DIFF
--- a/.github/workflows/ocd3-notify.yml
+++ b/.github/workflows/ocd3-notify.yml
@@ -32,5 +32,5 @@ jobs:
           webhook_type: 'json-extended'
           webhook_url: ${{ inputs.webhook-url }}
           webhook_auth: ${{ secrets.OCD3_USERNAME }}:${{ secrets.OCD3_PASSWORD }}
-          data: "{ \"ref\": \"${{ github.event_name == 'schedule' && github.event.repository.default_branch || github.ref }}\" }"
+          data: "{ \"ref\": \"${{ github.ref }}\" }"
           verbose: true


### PR DESCRIPTION
This PR removes unary operator which was probably an attempt to work around an issue with github context but based on this https://github.com/dhimmel/dump-actions-context/tree/main/contexts all events should have github.ref now.