### PR TITLE
Compare dependency reports using the Dependency Tracker

### DIFF
--- a/.github/workflows/maven-check-deps-build-publish.yml
+++ b/.github/workflows/maven-check-deps-build-publish.yml
@@ -73,7 +73,7 @@ jobs:
   check-for-dependency-changes:
     timeout-minutes: ${{ inputs.check-deps-timeout-minutes }}
     outputs:
-      hasChanged: ${{ steps.compareDependencyChanges.outputs.hasChanged }}
+      hasChanged: ${{ steps.compareDependencyReports.outputs.hasChanged }}
     runs-on: ubuntu-latest
 
     steps:
@@ -122,7 +122,7 @@ jobs:
             }]
 
       - name: Check for dependency changes
-        id: compareDependencyChanges
+        id: compareDependencyReports
         env:
           MAVEN_ARGS: ${{ inputs.check-deps-maven-args }}
           MAVEN_PHASE: ${{ inputs.check-deps-maven-phase }}
@@ -130,87 +130,51 @@ jobs:
         run: |
           #!/usr/bin/env bash
           set -e
-          
+
           # Initialize hasChanged to 0
           hasChanged=0
-          
-          # Download the remote dependency report
-          remoteRepoUrl=https://nexus.mekomsolutions.net/repository/maven-public
-          
-          # Get the list of sub-modules
-          modules=$(mvn -q $MAVEN_ARGS --also-make exec:exec -Dexec.executable="echo" -Dexec.args='${project.build.directory}')
-          
-          echo "List of modules to check for dependency changes:"
-          echo "$modules"
-          
-          # Build the local dependency report
-          echo "Compile a local dependency report..."
-          mvn --batch-mode --no-transfer-progress clean $MAVEN_PHASE $MAVEN_ARGS
-          
-          # Iterate over each module
-          for module in $modules; do
-            modulePath=$(echo $module | sed 's/\\/\//g')
-          
-            # Navigate to the module directory
-            cd $(dirname $modulePath)
-          
-            # Get the groupId, artifactId, and version
-            groupId=$(mvn help:evaluate -Dexpression=project.groupId -q -DforceStdout)
-            artifactId=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)
-            version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-            classifier=$(mvn help:evaluate -Dexpression=dependencyReportClassifier -q -DforceStdout)
-            artifact="${groupId}":"${artifactId}":"${version}":txt:"${classifier}"
-          
-            filename=${artifactId}-${version}-${classifier}.txt
-            absolutePath=/tmp/$filename
-          
-            # Remove previous file if any
-            rm -f "${absolutePath}"
-          
-            # Fetch the remote dependency report
-            echo "Fetch remote dependency report ${artifact}..."
-            set +e
-            mvn --batch-mode --no-transfer-progress org.apache.maven.plugins:maven-dependency-plugin:3.6.0:get -DremoteRepositories=${remoteRepoUrl} -Dartifact=${artifact} -Dtransitive=false
-            mvn --batch-mode --no-transfer-progress org.apache.maven.plugins:maven-dependency-plugin:3.6.0:copy -Dartifact=${artifact} -DoutputDirectory=/tmp/ -Dmdep.useBaseVersion=true
-            set -e
-          
-            # If no dependency report was fetched, create an empty one.
-            if [ ! -f "$absolutePath" ]; then
-              echo "Remote dependency file is not found at '${absolutePath}'. Creating an empty one and continue."
-              touch "${absolutePath}"
-            else
-              echo "Remote dependency file saved at '${absolutePath}'."
-            fi
-          
-            # Compare the 2 files. Will exit with 0 if no change, 1 if changes
-            echo "Compare both dependency reports..."
-            set +e
-            if [ -f ./target/"${filename}" ]; then
-              diff "${absolutePath}" ./target/"${filename}"
-              diff_rc=$?
-            
-            if [ $diff_rc -eq 0 ]; then
-              echo "No dependency change. Exit (0)"
-            elif [ $diff_rc -eq 1 ]; then
-              echo "One or more dependency has changed. Exit (1)"
-               # Set hasChanged to 1 (true) if a difference is found
+
+          # Run the build (comparison will be done during build)
+          mvn --batch-mode --no-transfer-progress clean compile
+
+          groupId=$(mvn help:evaluate -Dexpression=project.groupId -q -DforceStdout)
+          artifactId=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)
+          version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+
+          comparisonFileName=${artifactId}-${version}-comparison.txt
+          comparisonFilePath=./target/${comparisonFileName}
+
+          comparisonResult=$(cat $comparisonFilePath)
+
+          case "$comparisonResult" in
+            -1)
+              # No remote dependency report found
+              echo "No remote dependency report found (comparison report contains '-1')."
+              echo "Will publish the project."
               hasChanged=1
-            else
-              echo "Unknown error occurred."
-            fi
-            else
-              echo "Local dependency report is not found at './target/${filename}'."
-              echo "Dependency changes not tracked. Exit (0)"
-            fi
-            set -e
-          
-            # Navigate back to the parent directory
-            cd -
-          done
-          
-          # Export hasChanged to be used in later steps of the GitHub workflow
+              ;;
+            0)
+              # No dependency change
+              echo "No dependency change (comparison report contains '0')."
+              echo "Will not publish the project."
+              hasChanged=0
+              ;;
+            1)
+              # Found dependency changes
+              echo "One or more dependency changes detected (comparison report contains '1')."
+              echo "Will publish the project."
+              hasChanged=1
+              ;;
+            *)
+              # Invalid output in comparison result file
+              echo "Invalid value. Comparison report value is neither -1, 0 or 1."
+              exit 1
+              ;;
+          esac
+
           echo hasChanged=$hasChanged >> "$GITHUB_OUTPUT"
           exit 0
+
 
   build:
     needs: check-for-dependency-changes


### PR DESCRIPTION
Improve the comparison of dependency reports so that it's done using the 'newly' introduced features in Maven Dependency Tracker (See: https://github.com/mekomsolutions/dependency-tracker-maven-plugin#dependency-report-comparison)

That way, the actual comparison is done in the Maven build and not in bash logic.
Bash only reads the output and sets the vars to publish or not.